### PR TITLE
Use fake, but not blank, S3 bucket name and prefix. 

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,8 +31,8 @@ default[:tapalcatl][:aws][:region] = 'us-east-1'
 default[:tapalcatl][:s3][:keypattern] = '/{prefix}/{hash}/{layer}/{z}/{x}/{y}.{fmt}'
 
 # these are expected to be set downstream
-default[:tapalcatl][:s3][:bucket] = ''
-default[:tapalcatl][:handler][:s3][:prefix] = ''
+default[:tapalcatl][:s3][:bucket] = 'put-your-bucket-name-here'
+default[:tapalcatl][:handler][:s3][:prefix] = 'put-your-prefix-here'
 
 # tapalcatl has a buffer pool to reduce GC pressure when copying large amounts
 # of data from the upstream server.


### PR DESCRIPTION
This means that `kitchen converge` works, although Tapalcatl isn't able to answer any requests with fake settings. Also, the strings here might be more useful (e.g: to grep for) than empty strings if we manage to misconfigure it somehow.