### PR TITLE
Simplify the default tapalcatl configuration

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,14 +30,23 @@ default[:tapalcatl][:mime] = {
 default[:tapalcatl][:expvars][:serve] = false
 default[:tapalcatl][:expvars][:log_interval] = 0
 
-# aws specific configuration
-default[:tapalcatl][:aws][:region] = 'us-east-1'
-default[:tapalcatl][:s3][:keypattern] = '/{prefix}/{hash}/{layer}/{z}/{x}/{y}.{fmt}'
-default[:tapalcatl][:s3][:healthcheck] = '/healthcheck.txt'
-
-# these are expected to be set downstream
-default[:tapalcatl][:s3][:bucket] = 'put-your-bucket-name-here'
-default[:tapalcatl][:handler][:s3][:prefix] = 'put-your-prefix-here'
+handler_cfg = {
+  'mime' => node[:tapalcatl][:mime],
+  'storage' => {
+    'tmp' => {
+      'type' => 'file',
+      'basedir' => '/tmp',
+      'metatilesize' => 1,
+      'layer' => 'all',
+    },
+  },
+  'pattern' => {
+    '/{z:[0-9]+}/{x:[0-9]+}/{y:[0-9]+}.{fmt}' => {
+      'storage' => 'tmp',
+    },
+  },
+}
+default[:tapalcatl][:handler_cfg_json] = handler_cfg.to_json
 
 # tapalcatl has a buffer pool to reduce GC pressure when copying large amounts
 # of data from the upstream server.

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -9,37 +9,9 @@
 
 include_recipe "runit"
 
-storage = {
-  's3' => {
-    'type' => 's3',
-    'bucket' => node[:tapalcatl][:s3][:bucket],
-    'keypattern' => node[:tapalcatl][:s3][:keypattern],
-    'layer' => 'all',
-    'metatilesize' => 1,
-    'healthcheck' => node[:tapalcatl][:s3][:healthcheck],
-  }
-}
-pattern = {
-  '/mapzen/vector/v1/all/{z:[0-9]+}/{x:[0-9]+}/{y:[0-9]+}.{fmt}' => {
-    'storage' => 's3',
-    'prefix' => node[:tapalcatl][:handler][:s3][:prefix],
-  }
-}
-handler_cfg = {
-  'aws' => {
-    'region' => node[:tapalcatl][:aws][:region],
-  },
-  'mime' => node[:tapalcatl][:mime],
-  'storage' => storage,
-  'pattern' => pattern,
-}
-
 template "#{node[:tapalcatl][:cfg_path]}/#{node[:tapalcatl][:cfg_file]}" do
   source 'tapalcatl-config.conf.erb'
   notifies :restart, 'runit_service[tapalcatl]', :delayed
-  variables(
-    handler_cfg: handler_cfg
-  )
 end
 
 url = "https://s3.amazonaws.com/mapzen.software/tile/tapalcatl/tapalcatl_server-#{node[:tapalcatl][:revision]}"

--- a/templates/default/tapalcatl-config.conf.erb
+++ b/templates/default/tapalcatl-config.conf.erb
@@ -1,5 +1,5 @@
 listen <%= node[:tapalcatl][:listen] %>
-handler <%= @handler_cfg.to_json %>
+handler <%= node[:tapalcatl][:handler_cfg_json] %>
 <%- if node[:tapalcatl][:healthcheck] -%>
 healthcheck <%= node[:tapalcatl][:healthcheck] %>
 <%- end -%>


### PR DESCRIPTION
This generates a simple tapalcatl handler configuration, with the idea that the handler json configuration will be completely replaced downstream.