### PR TITLE
Increase nofile limit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Attributes
     <td>The user's name.</td>
     <td><tt>tapalcatl</tt></td>
   </tr>
+  <tr>
+    <td><tt>['tapalcatl']['limits']['open_files']</tt></td>
+    <td>Integer</td>
+    <td>The maximum number of open file descriptors allowed.</td>
+    <td>The value in <tt>/proc/sys/fs/file-max</tt></td>
+  </tr>
 </table>
 
 Contributing

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -72,3 +72,7 @@ default[:tapalcatl][:metrics][:enabled] = false
 default[:tapalcatl][:metrics][:statsd][:addr] = ''
 # prefix used when sending metrics to statsd
 default[:tapalcatl][:metrics][:statsd][:prefix] = ''
+
+# most modern systems can handle lots and lots of open files, so it seems
+# safe to set the default quite high.
+default[:tapalcatl][:limits][:open_file] = 16384

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -73,6 +73,6 @@ default[:tapalcatl][:metrics][:statsd][:addr] = ''
 # prefix used when sending metrics to statsd
 default[:tapalcatl][:metrics][:statsd][:prefix] = ''
 
-# most modern systems can handle lots and lots of open files, so it seems
-# safe to set the default quite high.
-default[:tapalcatl][:limits][:open_file] = 16384
+# default to using whatever the maximum is that the system advertises in
+# /proc/sys/fs/file-max. override to set a specific (lower) value.
+default[:tapalcatl][:limits][:open_files] = nil

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -32,6 +32,19 @@ directory '/var/log/tapalcatl' do
   recursive true
 end
 
+# set the default to the max if there's no default set
+ruby_block "set default ulimit" do
+  block do
+    unless node.default[:tapalcatl][:limits][:open_files]
+      max = File.read('/proc/sys/fs/file-max').to_i
+      # sanity check
+      if max >= 1024
+        node.default[:tapalcatl][:limits][:open_files] = max
+      end
+    end
+  end
+end
+
 runit_service 'tapalcatl' do
   action [:enable]
   log true

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -26,6 +26,12 @@ execute 'allow tapalcatl to bind on <1024 ports' do
   command 'setcap cap_net_bind_service=+ep ' + node[:tapalcatl][:bin] + '/tapalcatl_server'
 end
 
+# create directory, since runit doesn't seem to do this automatically
+directory '/var/log/tapalcatl' do
+  action :create
+  recursive true
+end
+
 runit_service 'tapalcatl' do
   action [:enable]
   log true

--- a/templates/default/sv-tapalcatl-run.erb
+++ b/templates/default/sv-tapalcatl-run.erb
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 exec 2>&1
-ulimit -n <%= node[:tapalcatl][:limits][:open_file] %>
+<% if node[:tapalcatl][:limits][:open_files] -%>
+ulimit -n <%= node[:tapalcatl][:limits][:open_files] %>
+<%- end %>
 exec chpst -u <%= node[:tapalcatl][:user][:user] %> \
      <%= node['tapalcatl']['bin'] %>/tapalcatl_server \
      -config <%= node[:tapalcatl][:cfg_path] + "/" + node[:tapalcatl][:cfg_file] %>

--- a/templates/default/sv-tapalcatl-run.erb
+++ b/templates/default/sv-tapalcatl-run.erb
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 exec 2>&1
+ulimit -n <%= node[:tapalcatl][:limits][:open_file] %>
 exec chpst -u <%= node[:tapalcatl][:user][:user] %> \
      <%= node['tapalcatl']['bin'] %>/tapalcatl_server \
      -config <%= node[:tapalcatl][:cfg_path] + "/" + node[:tapalcatl][:cfg_file] %>

--- a/test/integration/default/bats/tapalcatl_installed.bats
+++ b/test/integration/default/bats/tapalcatl_installed.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
 
 @test "tapalcatl server binary is installed" {
-  [ -x "/opt/go/bin/tapalcatl_server" ]
+  [ -x "/usr/local/bin/tapalcatl_server" ]
 }

--- a/test/integration/default/bats/tapalcatl_nofile.bats
+++ b/test/integration/default/bats/tapalcatl_nofile.bats
@@ -1,7 +1,19 @@
 #!/usr/bin/env bats
 
-@test "tapalcatl limit on open files is increased" {
+@test "proc max files is a number" {
+  max=`cat /proc/sys/fs/file-max`
+  [ "$max" -gt 1024 ]
+}
+
+@test "default limit on open files exists in runit config" {
+  max=`cat /proc/sys/fs/file-max`
+  count=`grep -c "^ulimit -n $max$" /etc/sv/tapalcatl/run`
+  [ "$count" -eq 1 ]
+}
+
+@test "tapalcatl limit on open files defaults to max" {
   pid=`ps aux | grep tapalcatl_server | grep -v grep | awk '{print $2;}' | head -n 1`
   nofile=`grep '^Max open files' /proc/$pid/limits | awk '{print $4;}'`
-  [ "$nofile" -eq 16384 ]
+  max=`cat /proc/sys/fs/file-max`
+  [ "$nofile" -eq "$max" ]
 }

--- a/test/integration/default/bats/tapalcatl_nofile.bats
+++ b/test/integration/default/bats/tapalcatl_nofile.bats
@@ -1,0 +1,7 @@
+#!/usr/bin/env bats
+
+@test "tapalcatl limit on open files is increased" {
+  pid=`ps aux | grep tapalcatl_server | grep -v grep | awk '{print $2;}' | head -n 1`
+  nofile=`grep '^Max open files' /proc/$pid/limits | awk '{print $4;}'`
+  [ "$nofile" -eq 16384 ]
+}


### PR DESCRIPTION
This will default to 16384, 16x what it was previously. This could go higher, but that seems like a reasonable limit for a modern machine.

Added a test for the nofile limit change. Fixed an existing test to account for the binary path change.

Added a directive to create the `/var/log/tapalcatl` directory, since converging a new instance seemed to fail when that was missing.